### PR TITLE
2 correctly translate fibts

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,10 +1,10 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
-  } else if (n == 0) {
+  } else if (n === 0) {
     return 0;
-  } else if (n == 1) {
+  } else if (n === 1) {
     return 1;
   }
 

--- a/src/fib.ts
+++ b/src/fib.ts
@@ -8,5 +8,5 @@ export default function fibonacci(n: number): number {
     return 1;
   }
 
-  return fibonacci(n - 1) + fibonacci(n - 2);
+  return (fibonacci(n - 1) as number) + (fibonacci(n - 2) as number);
 }


### PR DESCRIPTION
Explicit typing of numbers and return types to avoid ambiguity of `any` typing 